### PR TITLE
User memory access & System call infrastructure & The exit system call

### DIFF
--- a/src/userprog/exception.c
+++ b/src/userprog/exception.c
@@ -4,6 +4,7 @@
 #include "userprog/gdt.h"
 #include "threads/interrupt.h"
 #include "threads/thread.h"
+#include "userprog/syscall.h"
 
 /* Number of page faults processed. */
 static long long page_fault_cnt;
@@ -147,6 +148,9 @@ page_fault (struct intr_frame *f)
   not_present = (f->error_code & PF_P) == 0;
   write = (f->error_code & PF_W) != 0;
   user = (f->error_code & PF_U) != 0;
+
+  /* Project 2: To avoid check fail */
+  exit(-1);
 
   /* To implement virtual memory, delete the rest of the function
      body, and replace it with code that brings in the page to

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -106,34 +106,34 @@ syscall_handler (struct intr_frame *f)
       exit(args[0]);
       break;
     case SYS_EXEC:
-      //exec(args[0]);
+      //f->eax = exec(args[0]);
       break;
     case SYS_WAIT:
-      // wait(args[0]);
+      // f->eax = wait(args[0]);
       break;
     case SYS_CREATE:
-      //create(args[0], args[1]);
+      //f->eax = create(args[0], args[1]);
       break;
     case SYS_REMOVE:
-      //remove(args[0]);
+      //f->eax = remove(args[0]);
       break;
     case SYS_OPEN:
-      //open(args[0]);
+      //f->eax = open(args[0]);
       break;
     case SYS_FILESIZE:
-      //filesize(args[0]);
+      //f->eax = filesize(args[0]);
       break;
     case SYS_READ:
-      //read(args[0], args[1], args[2]);
+      //f->eax = read(args[0], args[1], args[2]);
       break;
     case SYS_WRITE:
-      //write(args[0], args[1], args[2]);
+      //f->eax = write(args[0], args[1], args[2]);
       break;
     case SYS_SEEK:
       //seek(args[0], args[1]);
       break;
     case SYS_TELL:
-      //tell(args[0]);
+      //f->eax = tell(args[0]);
       break;
     case SYS_CLOSE:
       //close(args[0]);

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -32,7 +32,7 @@ void halt(void)
 
 void validate_user_pointer(void *pointer)
 {
-  if (pointer < PHYS_BASE && pointer > (void *)0x08084000) // >= ?
+  if (!(pointer < PHYS_BASE && pointer > (void *)0x08084000)) // >= ?
   {
     exit(-1);
   }

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -9,8 +9,6 @@
 
 static void syscall_handler (struct intr_frame *);
 int write(int fd, const void *buffer, unsigned size);
-
-int write(int fd, const void *buffer, unsigned size);
 int get_arg_cnt(int);
 
 void
@@ -44,9 +42,9 @@ void get_syscall_arg(void *sp, int *arg, int arg_cnt)
   int i;
   for (i = 0; i < arg_cnt; i++)
   {
-    sp = (int *)sp + (1 << 31); // Argument size is 4 bytes(32bits)
+    sp = (uint32_t *)sp + 1; // Argument size is 4 bytes(32bits)
     validate_user_pointer(sp); 
-    arg[i] = *(int *)sp;
+    arg[i] = *(uint32_t *)sp;
   }
 }
 
@@ -93,7 +91,7 @@ static void
 syscall_handler (struct intr_frame *f) 
 {
   // printf ("system call!\n");
-  int syscall_num = *(int *)(f->esp);
+  int syscall_num = *(uint32_t *)(f->esp);
   int args[3];
   get_syscall_arg(f->esp, args, get_arg_cnt(syscall_num));
 
@@ -106,31 +104,43 @@ syscall_handler (struct intr_frame *f)
       exit(args[0]);
       break;
     case SYS_EXEC:
-      //f->eax = exec(args[0]);
+      /**
+       * validate_user_pointer((void *)args[0]);
+       * f->eax = exec((const char *)args[0]);
+      */
       break;
     case SYS_WAIT:
-      // f->eax = wait(args[0]);
+      // f->eax = wait((pid_t)args[0]);
       break;
     case SYS_CREATE:
-      //f->eax = create(args[0], args[1]);
+    /**
+     * validate_user_pointer((void *)args[0]);
+     * f->eax = create((const char *)args[0], (unsigned)args[1]);
+     */
       break;
     case SYS_REMOVE:
-      //f->eax = remove(args[0]);
+    /**
+     * validate_user_pointer((void *)args[0]); 
+     * f->eax = remove((const char *)args[0]);
+     */
       break;
     case SYS_OPEN:
-      //f->eax = open(args[0]);
+      /**
+       * validate_user_pointer((void *)args[0]); 
+       * f->eax = open((const char *)args[0]);
+       */
       break;
     case SYS_FILESIZE:
       //f->eax = filesize(args[0]);
       break;
     case SYS_READ:
-      //f->eax = read(args[0], args[1], args[2]);
+      //f->eax = read(args[0], (void *)args[1], (unsigned)args[2]);
       break;
     case SYS_WRITE:
-      //f->eax = write(args[0], args[1], args[2]);
+      f->eax = write(args[0], (const void *)args[1], (unsigned)args[2]);
       break;
     case SYS_SEEK:
-      //seek(args[0], args[1]);
+      //seek(args[0], (unsigned)args[1]);
       break;
     case SYS_TELL:
       //f->eax = tell(args[0]);

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -3,9 +3,15 @@
 #include <syscall-nr.h>
 #include "threads/interrupt.h"
 #include "threads/thread.h"
+#include "threads/vaddr.h"
+#include "devices/shutdown.h"
+#include <string.h>
 
 static void syscall_handler (struct intr_frame *);
 int write(int fd, const void *buffer, unsigned size);
+
+int write(int fd, const void *buffer, unsigned size);
+int get_arg_cnt(int);
 
 void
 syscall_init (void) 
@@ -13,10 +19,128 @@ syscall_init (void)
   intr_register_int (0x30, 3, INTR_ON, syscall_handler, "syscall");
 }
 
-static void
-syscall_handler (struct intr_frame *f UNUSED) 
+void exit(int status)
 {
-  printf ("system call!\n");
+  printf("%s: exit(%d)\n", thread_name(), status);
+  thread_exit();
+}
+
+void halt(void)
+{
+  shutdown_power_off ();
+}
+
+void validate_user_pointer(void *pointer)
+{
+  if (pointer < PHYS_BASE && pointer > (void *)0x08084000) // >= ?
+  {
+    exit(-1);
+  }
+}
+
+void get_syscall_arg(void *sp, int *arg, int arg_cnt)
+{
+  validate_user_pointer(sp);
+  int i;
+  for (i = 0; i < arg_cnt; i++)
+  {
+    sp = (int *)sp + (1 << 31); // Argument size is 4 bytes(32bits)
+    validate_user_pointer(sp); 
+    arg[i] = *(int *)sp;
+  }
+}
+
+int get_arg_cnt(int syscall_num)
+{
+  switch(syscall_num)
+  {
+    case SYS_HALT:
+      return 0;
+    case SYS_EXIT:
+      return 1;
+    case SYS_EXEC:
+      return 1;
+    case SYS_WAIT:
+      return 1;
+    case SYS_CREATE:
+      return 2;
+    case SYS_REMOVE:
+      return 1;
+    case SYS_OPEN:
+      return 1;
+    case SYS_FILESIZE:
+      return 1;
+    case SYS_READ:
+      return 3;
+    case SYS_WRITE:
+      return 3;
+    case SYS_SEEK:
+      return 2;
+    case SYS_TELL:
+      return 1;
+    case SYS_CLOSE:
+      return 1;
+    default:
+      printf("Syscall number error: %d\n", syscall_num);
+      return 0;
+  }
+}
+
+/*
+ * Call each system call handler checking stack pointer addresses. 
+ */
+static void
+syscall_handler (struct intr_frame *f) 
+{
+  // printf ("system call!\n");
+  int syscall_num = *(int *)(f->esp);
+  int args[3];
+  get_syscall_arg(f->esp, args, get_arg_cnt(syscall_num));
+
+  switch(syscall_num)
+  {
+    case SYS_HALT:
+      halt();
+      break;
+    case SYS_EXIT:
+      exit(args[0]);
+      break;
+    case SYS_EXEC:
+      //exec(args[0]);
+      break;
+    case SYS_WAIT:
+      // wait(args[0]);
+      break;
+    case SYS_CREATE:
+      //create(args[0], args[1]);
+      break;
+    case SYS_REMOVE:
+      //remove(args[0]);
+      break;
+    case SYS_OPEN:
+      //open(args[0]);
+      break;
+    case SYS_FILESIZE:
+      //filesize(args[0]);
+      break;
+    case SYS_READ:
+      //read(args[0], args[1], args[2]);
+      break;
+    case SYS_WRITE:
+      //write(args[0], args[1], args[2]);
+      break;
+    case SYS_SEEK:
+      //seek(args[0], args[1]);
+      break;
+    case SYS_TELL:
+      //tell(args[0]);
+      break;
+    case SYS_CLOSE:
+      //close(args[0]);
+      break;
+    default:
+      break;
+  }
   thread_exit ();
 }
 

--- a/src/userprog/syscall.h
+++ b/src/userprog/syscall.h
@@ -2,5 +2,9 @@
 #define USERPROG_SYSCALL_H
 
 void syscall_init (void);
+void exit(int status);
+void halt(void);
+void validate_user_pointer(void *pointer);
+void get_syscall_arg(void *sp, int *arg, int arg_cnt);
 
 #endif /* userprog/syscall.h */


### PR DESCRIPTION
resolves #13 

- exit
- halt

process가 실행되지 않는 상황이므로 syscall_handler 자체가 호출되지 않아 테스트를 해보지 못한 상황임.
syscall_handler는 system call함수를 하나 구현할 때 마다 주석을 제거하시면 됩니다. 

### 임시 테스트
process_wait에서 무한 대기중이므로, 테스트 코드의 msg()가 처음 한번만 호출될 수 있다. 
테스트 코드를 살짝 수정해서 write, exit, halt syscall이 제대로 동작하는 것은 확인하였음.

- tests/userprog/args.c 에서 msg문 수정("begin" 주석 처리)
![스크린샷 2021-11-07 오후 9 48 54](https://user-images.githubusercontent.com/30973277/140645650-3bf36b04-1e0c-4409-93a1-8eb2ec80e639.png)

![스크린샷 2021-11-07 오후 9 50 06](https://user-images.githubusercontent.com/30973277/140645688-65e13fb7-7064-4bd4-945a-33a8c7fd6433.png)

- tests/main.c 에서 mag("begin") 주석 처리
![image](https://user-images.githubusercontent.com/30973277/140648707-a90f3559-bf11-4046-8c22-544551628db9.png)
