### PR TITLE
15 user process

### DIFF
--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -464,6 +464,18 @@ init_thread (struct thread *t, const char *name, int priority)
   t->priority = priority;
   t->magic = THREAD_MAGIC;
 
+  #ifdef USERPROG
+  t->parent = thread_current();
+  list_init(&t->children);
+  sema_init(&t->exec_sema, 0);
+  sema_init(&t->wait_sema, 0);
+  t->load_status = 0;
+  t->exit_status = 0;
+  t->wait_status = false;
+  t->is_terminated = false;
+  list_push_back(&t->parent->children, &t->child_elem);
+  #endif
+
   old_level = intr_disable ();
   list_push_back (&all_list, &t->allelem);
   intr_set_level (old_level);

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -550,7 +550,7 @@ thread_schedule_tail (struct thread *prev)
   if (prev != NULL && prev->status == THREAD_DYING && prev != initial_thread) 
     {
       ASSERT (prev != cur);
-      palloc_free_page (prev);
+      //palloc_free_page (prev);
     }
 }
 

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -198,6 +198,17 @@ thread_create (const char *name, int priority,
   sf->eip = switch_entry;
   sf->ebp = 0;
 
+#ifdef USERPROG
+  t->parent = thread_current();
+  sema_init(&t->exec_sema, 0);
+  sema_init(&t->wait_sema, 0);
+  t->load_status = 0;
+  t->exit_status = 0;
+  t->wait_status = false;
+  t->is_terminated = false;
+  list_push_back(&t->parent->children, &t->child_elem);
+#endif
+
   /* Add to run queue. */
   thread_unblock (t);
 
@@ -465,15 +476,7 @@ init_thread (struct thread *t, const char *name, int priority)
   t->magic = THREAD_MAGIC;
 
   #ifdef USERPROG
-  t->parent = thread_current();
   list_init(&t->children);
-  sema_init(&t->exec_sema, 0);
-  sema_init(&t->wait_sema, 0);
-  t->load_status = 0;
-  t->exit_status = 0;
-  t->wait_status = false;
-  t->is_terminated = false;
-  list_push_back(&t->parent->children, &t->child_elem);
   #endif
 
   old_level = intr_disable ();

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -4,6 +4,7 @@
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>
+#include "threads/synch.h"
 
 /* States in a thread's life cycle. */
 enum thread_status

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -96,6 +96,16 @@ struct thread
 #ifdef USERPROG
     /* Owned by userprog/process.c. */
     uint32_t *pagedir;                  /* Page directory. */
+    struct thread *parent;
+    struct list children;
+    struct list_elem child_elem;
+    struct semaphore exec_sema;
+    struct semaphore wait_sema;
+    int load_status;                      /* 0 : Not loaded yet. / 1 : Load succeeded. / -1 : Load failed. */
+    int exit_status;
+    bool wait_status;                     /* true : This thread is already waited by parent / false : Not being waited. */
+    bool is_terminated;
+
 #endif
 
     /* Owned by thread.c. */

--- a/src/userprog/process.c
+++ b/src/userprog/process.c
@@ -86,7 +86,7 @@ start_process (void *file_name_)
 
   sema_up(&t->exec_sema);
 
-  hex_dump(if_.esp, if_.esp, PHYS_BASE - if_.esp, true);
+  //hex_dump(if_.esp, if_.esp, PHYS_BASE - if_.esp, true);
 
   /* If load failed, quit. */
   palloc_free_page (file_name);

--- a/src/userprog/process.h
+++ b/src/userprog/process.h
@@ -7,5 +7,7 @@ tid_t process_execute (const char *file_name);
 int process_wait (tid_t);
 void process_exit (void);
 void process_activate (void);
+struct thread *get_child(tid_t pid);
+void remove_child(struct thread *child);
 
 #endif /* userprog/process.h */

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -19,6 +19,11 @@ syscall_init (void)
   intr_register_int (0x30, 3, INTR_ON, syscall_handler, "syscall");
 }
 
+void halt(void)
+{
+  shutdown_power_off ();
+}
+
 void exit(int status)
 {
   thread_current()->exit_status = status;
@@ -39,9 +44,9 @@ pid_t exec (const char *cmd_line)
   else return -1;   //load_status == 0(which means process is not loaded yet. should not happen)
 }
 
-void halt(void)
+int wait (pid_t pid)
 {
-  shutdown_power_off ();
+  return process_wait(pid);
 }
 
 void validate_user_pointer(void *pointer)
@@ -120,13 +125,11 @@ syscall_handler (struct intr_frame *f)
       exit(args[0]);
       break;
     case SYS_EXEC:
-      /**
-       * validate_user_pointer((void *)args[0]);
-       * f->eax = exec((const char *)args[0]);
-      */
+       validate_user_pointer((void *)args[0]);
+       f->eax = exec((const char *)args[0]);
       break;
     case SYS_WAIT:
-      // f->eax = wait((pid_t)args[0]);
+      f->eax = wait((pid_t)args[0]);
       break;
     case SYS_CREATE:
     /**

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -170,7 +170,6 @@ syscall_handler (struct intr_frame *f)
     default:
       break;
   }
-  thread_exit ();
 }
 
 int write(int fd, const void *buffer, unsigned size)

--- a/src/userprog/syscall.h
+++ b/src/userprog/syscall.h
@@ -1,8 +1,11 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
 
+typedef int pid_t;
+
 void syscall_init (void);
 void exit(int status);
+pid_t exec (const char *cmd_line);
 void halt(void);
 void validate_user_pointer(void *pointer);
 void get_syscall_arg(void *sp, int *arg, int arg_cnt);

--- a/src/userprog/syscall.h
+++ b/src/userprog/syscall.h
@@ -4,9 +4,10 @@
 typedef int pid_t;
 
 void syscall_init (void);
+void halt(void);
 void exit(int status);
 pid_t exec (const char *cmd_line);
-void halt(void);
+int wait (pid_t pid);
 void validate_user_pointer(void *pointer);
 void get_syscall_arg(void *sp, int *arg, int arg_cnt);
 


### PR DESCRIPTION
- Process hierachy를 위한 구조체 변경(thread.h 참고)
- thread_schedule_tail()에서 스레드 메모리 삭제하지 않도록 변경
   - 부모 스레드가 exit status를 참고할 수 있게 하기 위함. 부모가 wait()을 할 경우 자식 스레드 삭제하도록 함.
   - 메모리 누수 가능성으로 추후 변경 필요.
- 자식 프로세스 검색 함수 get_child() 추가
- 자식 프로세스 삭제 함수 remove_child() 추가
- start_process()에서 load_status 저장 및 부모 프로세스 재개를 위해 sema_up()
- process_wait() 구현
- process_exit()에서 프로세스 종료 여부 저장,  wait 중인 부모 프로세스 재개를 위한 sema_up()
- exec() 구현
- exit()에서 프로세스 종료 상태 저장
issue #15 